### PR TITLE
PP-12123: Allow envsubst of job name to allow pushgateway grouping keys

### DIFF
--- a/check
+++ b/check
@@ -1,3 +1,3 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 echo "[]"

--- a/in
+++ b/in
@@ -1,3 +1,3 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 echo '{"version":{"ref":"none"}}'

--- a/out
+++ b/out
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 

--- a/out
+++ b/out
@@ -28,6 +28,7 @@ labels="$(jq -r '.params.labels' < "${payload}")"
 # if we have a job in the parameters, override job in source
 job=""
 if [[ $job_from_params == 'null' ]]; then job=$job_from_source; else job=$job_from_params; fi
+job=$(echo "${job}" | envsubst)
 
 # if we have a set of lables, flatten them into comma-separated string
 if [[ ${labels} != 'null' ]]; then

--- a/test/all.sh
+++ b/test/all.sh
@@ -73,3 +73,8 @@ test 'metric_with_env_vars' | jq -e "
     .pushgw_url == $(echo 'http://pushgw:9091' | jq -R .) and
     .body == \"${expected_body}\" and
     .job == $(echo 'metric_with_env_vars' | jq -R .)"
+
+test 'job_with_env_vars' | jq -e "
+    .pushgw_url == $(echo 'http://pushgw:9091' | jq -R .) and
+    .body == $(echo 'simple_metric 0' | jq -R .) and
+    .job == $(echo 'simple_metric/pipeline/my-pipeline' | jq -R .)"

--- a/test/job_with_env_vars.out
+++ b/test/job_with_env_vars.out
@@ -1,0 +1,11 @@
+{
+  "source": {
+    "url": "http://pushgw:9091",
+    "job": "simple_metric/pipeline/$BUILD_PIPELINE_NAME",
+    "debug": "true"
+  },
+  "params": {
+    "metric": "simple_metric",
+    "value": 0
+  }
+}


### PR DESCRIPTION
With the pushgateway when you push a metric the URL you push to is used as grouping key, if you push 2 metrics with different labels to the same grouping key the later put overwrites the earlier put, even if the labels are otherwise different, as such we need to be able to override the grouping key, and in that instance we want to be able to use the concourse metavariables like the pipeline name and job name.

For more info on grouping keys see https://github.com/prometheus/pushgateway?tab=readme-ov-file#url

This PR runs the job name through envsubst so we can use the concourse metavariables provided to the task (as is already done for the labels) in the url as grouping keys, allowing a job name like:

`my-metric/pipeline/$BUILD_PIPELINE_NAME/job/${BUILD_JOB_NAME}`

I've followed the existing conventions from the upstream exactly in how the tests are written and executed.

I've also done a docker build locally (which runs the tests) and it passed, I tried expecting a different output and the test failed which showed my test to be working correctly.