### PR TITLE
BAU: Make curl fail when an error is received from the pushgateway

### DIFF
--- a/out
+++ b/out
@@ -53,7 +53,7 @@ EOF
     )"
 else
     echo "Metric sent to Pushgateway: '${body}'" >&2
-    echo "${body}" | curl --data-binary @- "${pushgw_url}/metrics/job/${job}"
+    echo "${body}" | curl --fail-with-body --data-binary @- "${pushgw_url}/metrics/job/${job}"
 fi
 
 timestamp="$(jq -n "{version:{timestamp:\"$(date +%s)\"}}")"


### PR DESCRIPTION
If curl fails to send the metric the put still succeeds since curl exits with a 0 code even on a 5XX error.

This isn't desirable since we want to know the metrics have actually been sent and attempt the put multiple times in case of error.

--fail-with-body will make curl exit error code 22 if the remote returns any 5XX error (and most 4XX errors), and also print out the response which will allow us to see why it failed.